### PR TITLE
Añade esqueleto web con TypeScript y Rust WASM

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+node_modules
+dist
+target
+rust-wasm/pkg
+

--- a/README.md
+++ b/README.md
@@ -1,1 +1,24 @@
+# ESTRUCTURAQUICK
+
 Subida inicial de ficheros.
+
+## Webapp
+
+Se añade un esqueleto de aplicación web basado en TypeScript y Three.js con soporte para
+módulos de alto rendimiento en Rust compilados a WebAssembly.
+
+- `webapp/`: interfaz web con Vite + TypeScript.
+- `rust-wasm/`: módulo Rust exportando funciones a WASM.
+
+Para desarrollar:
+
+```bash
+cd webapp
+npm install   # actualmente falla por restricciones de red
+npm run dev
+```
+
+```bash
+cd rust-wasm
+cargo build --target wasm32-unknown-unknown # puede fallar si no se puede descargar crates
+```

--- a/rust-wasm/Cargo.toml
+++ b/rust-wasm/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "representatodo_wasm"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+wasm-bindgen = "0.2"

--- a/rust-wasm/src/lib.rs
+++ b/rust-wasm/src/lib.rs
@@ -1,0 +1,6 @@
+use wasm_bindgen::prelude::*;
+
+#[wasm_bindgen]
+pub fn greet(name: &str) -> String {
+    format!("Hola, {}!", name)
+}

--- a/webapp/index.html
+++ b/webapp/index.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="es">
+  <head>
+    <meta charset="UTF-8" />
+    <title>RepresentaTodo Web</title>
+    <script type="module" src="/src/main.ts"></script>
+  </head>
+  <body>
+  </body>
+</html>

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "representatodo-web",
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "test": "tsc --noEmit"
+  },
+  "dependencies": {
+    "three": "^0.157.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.0.0",
+    "vite": "^4.0.0"
+  }
+}

--- a/webapp/src/main.ts
+++ b/webapp/src/main.ts
@@ -1,0 +1,27 @@
+import * as THREE from 'three';
+
+function init() {
+  const scene = new THREE.Scene();
+  const camera = new THREE.PerspectiveCamera(75, window.innerWidth / window.innerHeight, 0.1, 1000);
+  const renderer = new THREE.WebGLRenderer();
+  renderer.setSize(window.innerWidth, window.innerHeight);
+  document.body.appendChild(renderer.domElement);
+
+  const geometry = new THREE.BoxGeometry();
+  const material = new THREE.MeshBasicMaterial({ color: 0x00ff00 });
+  const cube = new THREE.Mesh(geometry, material);
+  scene.add(cube);
+
+  camera.position.z = 5;
+
+  function animate() {
+    requestAnimationFrame(animate);
+    cube.rotation.x += 0.01;
+    cube.rotation.y += 0.01;
+    renderer.render(scene, camera);
+  }
+
+  animate();
+}
+
+init();

--- a/webapp/src/wasm.ts
+++ b/webapp/src/wasm.ts
@@ -1,0 +1,6 @@
+import init, { greet } from '../../rust-wasm/pkg/representatodo_wasm';
+
+export async function greetFromWasm(name: string): Promise<string> {
+  await init();
+  return greet(name);
+}

--- a/webapp/tsconfig.json
+++ b/webapp/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "strict": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "outDir": "dist"
+  },
+  "include": ["src"]
+}

--- a/webapp/vite.config.ts
+++ b/webapp/vite.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+  root: '.',
+  build: {
+    outDir: 'dist'
+  }
+});


### PR DESCRIPTION
## Summary
- Agrega carpeta `webapp` con Vite, TypeScript y ejemplo Three.js
- Añade módulo `rust-wasm` preparado para compilar a WebAssembly
- Actualiza README con instrucciones básicas y agrega `.gitignore`

## Testing
- `npm test` *(falló: Cannot find module 'three'; sin dependencias instaladas)*
- `cargo test` *(falló: failed to download from crates.io, respuesta 403)*

------
https://chatgpt.com/codex/tasks/task_e_68984fed58388322a6b8507ecf706289